### PR TITLE
feat(batch-001): MVP+ feature pack

### DIFF
--- a/__tests__/ai.test.ts
+++ b/__tests__/ai.test.ts
@@ -1,0 +1,23 @@
+import { summarizeNote, generateFlashcards, explainConcept } from '../services/ai';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ choices: [{ message: { content: '{"a":"b"}' } }] }) })
+) as any;
+
+describe('AI service', () => {
+  it('summarizeNote returns text', async () => {
+    const text = await summarizeNote('hello');
+    expect(text).toBe('{"a":"b"}');
+  });
+
+  it('generateFlashcards parses JSON', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ choices: [{ message: { content: '[{"front":"f","back":"b"}]' } }] }) });
+    const cards = await generateFlashcards('note');
+    expect(cards[0].front).toBe('f');
+  });
+
+  it('explainConcept returns text', async () => {
+    const text = await explainConcept('concept');
+    expect(text).toBe('{"a":"b"}');
+  });
+});

--- a/__tests__/spacedRepetition.test.ts
+++ b/__tests__/spacedRepetition.test.ts
@@ -1,0 +1,9 @@
+import { scheduleNextReview } from '../utils/spacedRepetition';
+
+describe('SM-2 scheduler', () => {
+  it('increases repetition on good quality', () => {
+    const updated = scheduleNextReview({ id: '1', noteId: 'n', front: 'f', back: 'b', tags: [], createdAt: '', updatedAt: '' } as any, 5);
+    expect(updated.repetitions).toBe(1);
+    expect(updated.nextReview).toBeGreaterThan(Date.now());
+  });
+});

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -22,6 +22,10 @@ export default function OnboardingLayout() {
       }}
     >
       <Stack.Screen name="index" />
+      <Stack.Screen name="create-account" />
+      <Stack.Screen name="select-subjects" />
+      <Stack.Screen name="upload-id" />
+      <Stack.Screen name="enable-notifications" />
       <Stack.Screen name="plan-selection" />
       <Stack.Screen name="tutorial" />
     </Stack>

--- a/app/onboarding/create-account.tsx
+++ b/app/onboarding/create-account.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'expo-router';
+import { useAuthStore } from '@/store/authStore';
+
+export default function CreateAccount() {
+  const router = useRouter();
+  const { signUp, isLoading } = useAuthStore();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+
+  const handleNext = async () => {
+    await signUp(email, password, name);
+    router.push('/onboarding/select-subjects');
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <Text style={styles.title}>Create Account</Text>
+      <TextInput placeholder="Name" style={styles.input} value={name} onChangeText={setName} />
+      <TextInput placeholder="Email" style={styles.input} autoCapitalize="none" value={email} onChangeText={setEmail} />
+      <TextInput placeholder="Password" style={styles.input} secureTextEntry value={password} onChangeText={setPassword} />
+      <Button title="Next" onPress={handleNext} loading={isLoading} style={styles.button} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 12, marginBottom: 12 },
+  button: { marginTop: 12 },
+});

--- a/app/onboarding/enable-notifications.tsx
+++ b/app/onboarding/enable-notifications.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'expo-router';
+
+export default function EnableNotifications() {
+  const router = useRouter();
+
+  const enable = async () => {
+    await Notifications.requestPermissionsAsync();
+    router.replace('/');
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <Text style={styles.title}>Enable Notifications</Text>
+      <Button title="Enable" onPress={enable} style={styles.button} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  button: { marginTop: 12 },
+});

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -41,7 +41,7 @@ export default function Onboarding() {
       <View style={styles.footer}>
         <TouchableOpacity
           style={styles.button}
-          onPress={() => router.push('/onboarding/plan-selection')}
+          onPress={() => router.push('/onboarding/create-account')}
         >
           <Text style={styles.buttonText}>Get Started</Text>
           <Ionicons name="arrow-forward" size={24} color="#fff" />

--- a/app/onboarding/select-subjects.tsx
+++ b/app/onboarding/select-subjects.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TextInput } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'expo-router';
+
+export default function SelectSubjects() {
+  const router = useRouter();
+  const [subjects, setSubjects] = useState('');
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <Text style={styles.title}>Select Subjects</Text>
+      <TextInput
+        placeholder="e.g. Math, Biology"
+        style={styles.input}
+        value={subjects}
+        onChangeText={setSubjects}
+      />
+      <Button title="Next" onPress={() => router.push('/onboarding/upload-id')} style={styles.button} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 12, marginBottom: 12 },
+  button: { marginTop: 12 },
+});

--- a/app/onboarding/upload-id.tsx
+++ b/app/onboarding/upload-id.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Image } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'expo-router';
+import { verifyStudentID } from '@/utils/sheerid';
+
+export default function UploadID() {
+  const router = useRouter();
+  const [image, setImage] = useState<string | null>(null);
+  const [verified, setVerified] = useState(false);
+
+  const pick = async () => {
+    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images });
+    if (!res.canceled && res.assets.length > 0) {
+      const uri = res.assets[0].uri;
+      setImage(uri);
+      const result = await verifyStudentID(uri);
+      setVerified(result.verified);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <Text style={styles.title}>Upload Student ID</Text>
+      {image && <Image source={{ uri: image }} style={{ width: 200, height: 120, alignSelf: 'center' }} />}
+      <Button title={image ? 'Reupload' : 'Upload'} onPress={pick} style={styles.button} />
+      <Button title="Next" disabled={!verified} onPress={() => router.push('/onboarding/enable-notifications')} style={styles.button} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  button: { marginTop: 12 },
+});

--- a/app/subscription/_layout.tsx
+++ b/app/subscription/_layout.tsx
@@ -5,6 +5,7 @@ export default function SubscriptionLayout() {
   return (
     <Stack>
       <Stack.Screen name="index" options={{ title: 'Subscription' }} />
+      <Stack.Screen name="paywall" options={{ title: 'Upgrade' }} />
     </Stack>
   );
-} 
+}

--- a/app/subscription/paywall.tsx
+++ b/app/subscription/paywall.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'expo-router';
+
+export default function Paywall() {
+  const router = useRouter();
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <Text style={styles.title}>DreamNotes Pro</Text>
+      <Text style={styles.subtitle}>Create unlimited notebooks and access AI features.</Text>
+      <Button title="Subscribe" onPress={() => {}} style={styles.button} />
+      <Button title="Restore" variant="outline" onPress={() => {}} style={styles.button} />
+      <Button title="Maybe Later" variant="ghost" onPress={() => router.back()} style={styles.button} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: 'center' },
+  title: { fontSize: 24, fontWeight: '600', textAlign: 'center' },
+  subtitle: { textAlign: 'center', marginVertical: 12 },
+  button: { marginTop: 12 },
+});

--- a/components/NotebookCanvas.tsx
+++ b/components/NotebookCanvas.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+let PencilKit: any;
+let SkiaView: any;
+try {
+  PencilKit = require('react-native-pencilkit').PencilKitView;
+} catch {}
+try {
+  SkiaView = require('@shopify/react-native-skia').Canvas;
+} catch {}
+
+interface Props {
+  onExport?: (png: string, strokes: string) => void;
+}
+
+export default function NotebookCanvas({ onExport }: Props) {
+  if (Platform.OS === 'ios' && PencilKit) {
+    return <PencilKit style={styles.canvas} onExport={onExport} />;
+  }
+  if (SkiaView) {
+    return <SkiaView style={styles.canvas} />;
+  }
+  return <View style={styles.canvas} />;
+}
+
+const styles = StyleSheet.create({
+  canvas: { flex: 1 },
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "~3.29.0",
     "sharp": "^0.34.2",
-    "zustand": "^4.5.1"
+    "zustand": "^4.5.1",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/store/progressStore.ts
+++ b/store/progressStore.ts
@@ -77,19 +77,15 @@ const useProgressStore = create<ProgressState & {
   addXP: (amount: number) => {
     const { progress } = get();
     if (!progress) return;
-    
-    // Calculate new XP and level
-    const newXP = progress.xp + amount;
-    
-    // Simple level calculation (adjust as needed)
-    // Level 1: 0-999 XP, Level 2: 1000-1999 XP, etc.
-    const newLevel = Math.floor(newXP / 1000) + 1;
-    
+
+    const totalXP = progress.xp + amount;
+    const level = Math.floor(Math.sqrt(totalXP / 10));
+
     set({
       progress: {
         ...progress,
-        xp: newXP,
-        level: newLevel,
+        xp: totalXP,
+        level,
       },
     });
   },

--- a/supabase/functions/xp_push.ts
+++ b/supabase/functions/xp_push.ts
@@ -1,0 +1,10 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.42.1'
+
+serve(async (req) => {
+  const { userId, amount } = await req.json()
+  const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+  await supabase.from('xp_log').insert({ user_id: userId, amount })
+  // send push notification using Supabase functions - stub
+  return new Response('ok')
+})

--- a/supabase/migrations/batch_001.sql
+++ b/supabase/migrations/batch_001.sql
@@ -1,0 +1,66 @@
+-- Users table
+create table if not exists users (
+  id uuid primary key,
+  email text not null unique,
+  name text not null,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- Notebooks table
+create table if not exists notebooks (
+  id uuid primary key,
+  user_id uuid references users(id) on delete cascade,
+  title text not null,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- Pages table
+create table if not exists pages (
+  id uuid primary key,
+  notebook_id uuid references notebooks(id) on delete cascade,
+  user_id uuid references users(id) on delete cascade,
+  content text,
+  strokes jsonb,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- Flashcards table
+create table if not exists flashcards (
+  id uuid primary key,
+  user_id uuid references users(id) on delete cascade,
+  note_id uuid references pages(id) on delete cascade,
+  front text,
+  back text,
+  repetitions int default 0,
+  ease_factor real default 2.5,
+  interval int default 1,
+  next_review timestamp with time zone,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- XP log
+create table if not exists xp_log (
+  id uuid primary key,
+  user_id uuid references users(id) on delete cascade,
+  amount int,
+  created_at timestamp with time zone default now()
+);
+
+alter table users enable row level security;
+create policy "users_is_self" on users for all using ( auth.uid() = id );
+
+alter table notebooks enable row level security;
+create policy "notebooks_is_owner" on notebooks for all using ( auth.uid() = user_id );
+
+alter table pages enable row level security;
+create policy "pages_is_owner" on pages for all using ( auth.uid() = user_id );
+
+alter table flashcards enable row level security;
+create policy "flashcards_is_owner" on flashcards for all using ( auth.uid() = user_id );
+
+alter table xp_log enable row level security;
+create policy "xp_log_is_owner" on xp_log for all using ( auth.uid() = user_id );

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,0 +1,13 @@
+import * as Notifications from 'expo-notifications';
+import { addDays, setHours, setMinutes } from 'date-fns';
+
+export async function scheduleDailyReminder() {
+  const trigger = setMinutes(setHours(new Date(), 19), 0);
+  if (trigger < new Date()) {
+    trigger.setDate(trigger.getDate() + 1);
+  }
+  await Notifications.scheduleNotificationAsync({
+    content: { title: 'Study streak!', body: 'Time to review your notes.' },
+    trigger: { hour: trigger.getHours(), minute: trigger.getMinutes(), repeats: true },
+  });
+}

--- a/utils/sheerid.ts
+++ b/utils/sheerid.ts
@@ -78,4 +78,11 @@ export async function verifyISIC(cardNumber: string): Promise<SheerIDVerificatio
       error: error instanceof Error ? error.message : 'Unknown error occurred',
     };
   }
-} 
+}
+
+export async function verifyStudentID(fileUri: string): Promise<{ verified: boolean }> {
+  // Mocked SheerID SDK - simply check that the file ends with .jpg or .jpeg
+  const isJpeg = fileUri.toLowerCase().endsWith('.jpg') || fileUri.toLowerCase().endsWith('.jpeg');
+  await new Promise(resolve => setTimeout(resolve, 300));
+  return { verified: isJpeg };
+}

--- a/utils/spacedRepetition.ts
+++ b/utils/spacedRepetition.ts
@@ -1,0 +1,17 @@
+import { Flashcard } from '@/types';
+
+export function scheduleNextReview(card: Flashcard, quality: number): Flashcard {
+  const q = Math.max(0, Math.min(5, quality));
+  const repetitions = (card.repetitions ?? 0) + (q >= 3 ? 1 : 0);
+  const ease = Math.max(1.3, (card.easeFactor ?? 2.5) + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02)));
+  const interval = repetitions === 1 ? 1 : repetitions === 2 ? 6 : Math.round((card.interval ?? 1) * ease);
+  const nextReview = Date.now() + interval * 24 * 60 * 60 * 1000;
+
+  return {
+    ...card,
+    repetitions,
+    easeFactor: ease,
+    interval,
+    nextReview,
+  };
+}


### PR DESCRIPTION
## Summary
- extend onboarding flow with account creation and verification steps
- add simple paywall screen
- implement AI helpers with exponential backoff
- compute levels from XP via sqrt formula
- add cross‑platform notebook canvas stub
- schedule daily reminders and provide SheerID mock
- include Supabase schema migration and edge function
- add SM-2 scheduling helper
- add unit tests for new helpers

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef6e21ef88322a1eb7f8e228ebd39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced a multi-step onboarding flow with new screens for account creation, subject selection, student ID upload, and notification enablement.
    - Added a subscription paywall screen with options to subscribe, restore, or skip.
    - Added a flexible notebook canvas supporting iOS PencilKit and Skia, with graceful fallback.
    - Implemented daily study reminder notifications at 7:00 PM.
    - Added spaced repetition scheduling for flashcards and a utility to verify student ID images.
    - Added serverless backend function to log experience points (XP).
- **Improvements**
    - Updated user level progression to a non-linear formula for a more gradual leveling experience.
- **Bug Fixes**
    - N/A
- **Tests**
    - Added comprehensive test suites for AI services and spaced repetition scheduling.
- **Chores**
    - Added the `date-fns` dependency.
- **Database**
    - Created new tables for users, notebooks, pages, flashcards, and XP logs with enhanced security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->